### PR TITLE
feat: Add adaptive strategy target suggestion and display candidate hands during target selection.

### DIFF
--- a/internal/application/manual_game_service.go
+++ b/internal/application/manual_game_service.go
@@ -649,7 +649,7 @@ func (s *ManualGameService) promptForTarget(actionType domain.ActionType, candid
 	suggested := adaptive.ChooseTarget(actionType, candidates, actor)
 
 	for i, c := range candidates {
-		fmt.Printf("%d. %s\n", i+1, s.formatCandidateOption(c, suggested))
+		fmt.Printf("%d. %s\n", i+1, s.FormatCandidateOption(c, suggested))
 	}
 
 	fmt.Print("Enter choice: ")
@@ -661,16 +661,20 @@ func (s *ManualGameService) promptForTarget(actionType domain.ActionType, candid
 	return candidates[idx-1]
 }
 
-// formatCandidateOption formats a candidate player for display in the selection list.
-// It includes the player's name, score, hand contents, and a suggestion marker if applicable.
-// Making this public (capitalized) or internal-exported allows for easier testing if needed,
-// but since it's a method on *ManualGameService, we can test it if we can instantiate the service.
-func (s *ManualGameService) formatCandidateOption(candidate *domain.Player, suggested *domain.Player) string {
+// FormatCandidateOption formats a candidate player for display in the selection list.
+// It includes the player's name, score, hand contents, and marks the suggested candidate.
+// Note: Returns "[]" for nil CurrentHand. In practice, this method is called during active
+// gameplay when all candidates have initialized hands, but the nil check provides defensive
+// programming against edge cases.
+func (s *ManualGameService) FormatCandidateOption(candidate *domain.Player, suggested *domain.Player) string {
 	marker := ""
 	if suggested != nil && candidate.ID == suggested.ID {
 		marker = " [Suggested]"
 	}
-	handStr := s.formatHand(candidate.CurrentHand)
+	handStr := "[]"
+	if candidate.CurrentHand != nil {
+		handStr = s.formatHand(candidate.CurrentHand)
+	}
 	return fmt.Sprintf("%s (Score: %d) Hand: %s%s", candidate.Name, candidate.TotalScore, handStr, marker)
 }
 

--- a/internal/application/manual_game_service_suggestion_test.go
+++ b/internal/application/manual_game_service_suggestion_test.go
@@ -1,13 +1,17 @@
-package application
+package application_test
 
 import (
+	"bufio"
+	"flip7_strategy/internal/application"
 	"flip7_strategy/internal/domain"
 	"strings"
 	"testing"
 )
 
+// TestFormatCandidateOption tests the formatting of candidate options
+// with various scenarios including suggested candidates and nil hands.
 func TestFormatCandidateOption(t *testing.T) {
-	service := &ManualGameService{}
+	service := &application.ManualGameService{}
 
 	candidate := domain.NewPlayer("Candidate", nil)
 	candidate.TotalScore = 150
@@ -17,7 +21,7 @@ func TestFormatCandidateOption(t *testing.T) {
 
 	t.Run("Suggested", func(t *testing.T) {
 		suggested := candidate // Same pointer
-		output := service.formatCandidateOption(candidate, suggested)
+		output := service.FormatCandidateOption(candidate, suggested)
 
 		if !strings.Contains(output, "[Suggested]") {
 			t.Errorf("Expected output to contain '[Suggested]', got: %s", output)
@@ -25,11 +29,14 @@ func TestFormatCandidateOption(t *testing.T) {
 		if !strings.Contains(output, "Candidate") {
 			t.Errorf("Expected output to contain name, got: %s", output)
 		}
+		if !strings.Contains(output, "Score: 150") {
+			t.Errorf("Expected output to contain score, got: %s", output)
+		}
 	})
 
 	t.Run("NotSuggested", func(t *testing.T) {
 		other := domain.NewPlayer("Other", nil)
-		output := service.formatCandidateOption(candidate, other)
+		output := service.FormatCandidateOption(candidate, other)
 
 		if strings.Contains(output, "[Suggested]") {
 			t.Errorf("Expected output NOT to contain '[Suggested]', got: %s", output)
@@ -37,7 +44,7 @@ func TestFormatCandidateOption(t *testing.T) {
 	})
 
 	t.Run("NilSuggested", func(t *testing.T) {
-		output := service.formatCandidateOption(candidate, nil)
+		output := service.FormatCandidateOption(candidate, nil)
 
 		if strings.Contains(output, "[Suggested]") {
 			t.Errorf("Expected output NOT to contain '[Suggested]' for nil suggestion, got: %s", output)
@@ -46,4 +53,102 @@ func TestFormatCandidateOption(t *testing.T) {
 			t.Errorf("Expected output to contain name, got: %s", output)
 		}
 	})
+
+	t.Run("NilCurrentHand", func(t *testing.T) {
+		candidateWithoutHand := domain.NewPlayer("NoHand", nil)
+		candidateWithoutHand.TotalScore = 100
+		// NewPlayer creates players with nil CurrentHand
+
+		output := service.FormatCandidateOption(candidateWithoutHand, nil)
+
+		if !strings.Contains(output, "NoHand") {
+			t.Errorf("Expected output to contain name, got: %s", output)
+		}
+		if !strings.Contains(output, "[]") {
+			t.Errorf("Expected output to contain empty hand '[]', got: %s", output)
+		}
+	})
 }
+
+// TestPromptForTargetSuggestionLogic tests the integration of AdaptiveStrategy
+// in the target selection process. Note: Full integration testing of promptForTarget
+// is challenging due to its interactive nature (stdout/stdin), so we focus on
+// verifying the suggestion logic works correctly when integrated into the service.
+func TestPromptForTargetSuggestionLogic(t *testing.T) {
+	// This test verifies that the suggestion logic in promptForTarget works correctly
+	// by testing the FormatCandidateOption method with realistic game scenarios.
+	// The actual AdaptiveStrategy.ChooseTarget behavior is tested in the strategy package.
+
+	t.Run("WithCurrentRound", func(t *testing.T) {
+		// Setup a game with a current round and deck
+		reader := bufio.NewReader(strings.NewReader("1\n"))
+		service := application.NewManualGameService(reader, nil)
+
+		// Initialize game with players
+		p1 := domain.NewPlayer("Player1", nil)
+		p2 := domain.NewPlayer("Player2", nil)
+		players := []*domain.Player{p1, p2}
+		service.Game = domain.NewGame(players)
+
+		// Start a new round to initialize CurrentRound and Deck
+		deck := domain.NewDeck()
+		service.Game.CurrentRound = domain.NewRound(players, p1, deck)
+
+		// Verify that with a CurrentRound, the deck is available for AdaptiveStrategy
+		if service.Game.CurrentRound == nil {
+			t.Fatal("Expected CurrentRound to be initialized")
+		}
+		if service.Game.CurrentRound.Deck == nil {
+			t.Fatal("Expected Deck to be initialized in CurrentRound")
+		}
+
+		// The actual suggestion logic is exercised in promptForTarget,
+		// but we can't easily test it without mocking stdout/stdin.
+		// We verify the components are in place and FormatCandidateOption
+		// works correctly with suggestions.
+		player1 := service.Game.Players[0]
+		player2 := service.Game.Players[1]
+
+		output := service.FormatCandidateOption(player1, player2)
+		if strings.Contains(output, "[Suggested]") {
+			t.Error("Expected player1 NOT to be marked as suggested when player2 is suggested")
+		}
+
+		output = service.FormatCandidateOption(player2, player2)
+		if !strings.Contains(output, "[Suggested]") {
+			t.Error("Expected player2 to be marked as suggested")
+		}
+	})
+
+	t.Run("WithoutCurrentRound", func(t *testing.T) {
+		// Verify that the service handles nil CurrentRound gracefully
+		reader := bufio.NewReader(strings.NewReader("1\n"))
+		service := application.NewManualGameService(reader, nil)
+
+		p1 := domain.NewPlayer("Player1", nil)
+		p2 := domain.NewPlayer("Player2", nil)
+		players := []*domain.Player{p1, p2}
+		service.Game = domain.NewGame(players)
+		// Don't start a round, so CurrentRound is nil
+
+		if service.Game.CurrentRound != nil {
+			t.Fatal("Expected CurrentRound to be nil")
+		}
+
+		// The service should still work and AdaptiveStrategy should handle nil deck
+		player1 := service.Game.Players[0]
+		player1.CurrentHand = &domain.PlayerHand{
+			RawNumberCards: []domain.NumberValue{3, 7},
+		}
+
+		// FormatCandidateOption should work even without CurrentRound
+		output := service.FormatCandidateOption(player1, nil)
+		if !strings.Contains(output, "Player1") {
+			t.Errorf("Expected output to contain player name, got: %s", output)
+		}
+		if !strings.Contains(output, "[3, 7]") {
+			t.Errorf("Expected output to contain hand, got: %s", output)
+		}
+	})
+}
+


### PR DESCRIPTION
This pull request enhances the user experience in the manual game service by introducing a target suggestion feature based on an adaptive strategy. Now, when prompting for a target, the system suggests a candidate using game context and highlights this suggestion in the list of options, along with each candidate's current hand.

**Target Selection Improvements:**

* Added logic to use `AdaptiveStrategy` for suggesting the most suitable target based on the current deck and action type. The suggested candidate is marked as "[Suggested]" in the selection prompt.
* Updated the prompt to display each candidate's current hand alongside their score, providing more context for the user's decision.

Closes: #59 