### PR TITLE
feat: Introduce 'SAVE' command to explicitly display game save code instead of automatically printing it after each turn.

### DIFF
--- a/internal/application/manual_game_service.go
+++ b/internal/application/manual_game_service.go
@@ -341,11 +341,7 @@ func (s *ManualGameService) playRound() {
 			continue
 		}
 
-		// Show Save Code
-		code, err := s.SaveState()
-		if err == nil {
-			fmt.Printf("\n[Save Code]: %s\n", code)
-		}
+		// Save Code is hidden by default. Use 'SAVE' command to view.
 
 		fmt.Printf("\n>>> Turn: %s (Score: %d)\n", currentPlayer.Name, currentPlayer.TotalScore)
 
@@ -370,7 +366,7 @@ func (s *ManualGameService) playRound() {
 		shouldRestartTurn := false
 
 		for !turnEnded {
-			fmt.Print("Input (0-12, +N, x2, F, T, C, S, U/UNDO/<, R/REDO/>): ")
+			fmt.Print("Input (0-12, +N, x2, F, T, C, S, U/UNDO/<, R/REDO/>, SAVE): ")
 			input, err := s.Reader.ReadString('\n')
 			if err != nil {
 				fmt.Println("Error reading input. Exiting game.")
@@ -378,6 +374,17 @@ func (s *ManualGameService) playRound() {
 				return
 			}
 			input = strings.TrimSpace(input)
+
+			// Check for commands
+			if strings.EqualFold(input, "SAVE") {
+				code, err := s.SaveState()
+				if err == nil {
+					fmt.Printf("\n[Save Code]: %s\n", code)
+				} else {
+					fmt.Printf("\nFailed to generate save code: %v\n", err)
+				}
+				continue
+			}
 
 			// Check for Undo/Redo
 			if strings.EqualFold(input, "U") || strings.EqualFold(input, "UNDO") || input == "<" {

--- a/internal/application/manual_game_service.go
+++ b/internal/application/manual_game_service.go
@@ -375,17 +375,6 @@ func (s *ManualGameService) playRound() {
 			}
 			input = strings.TrimSpace(input)
 
-			// Check for commands
-			if strings.EqualFold(input, "SAVE") {
-				code, err := s.SaveState()
-				if err == nil {
-					fmt.Printf("\n[Save Code]: %s\n", code)
-				} else {
-					fmt.Printf("\nFailed to generate save code: %v\n", err)
-				}
-				continue
-			}
-
 			// Check for Undo/Redo
 			if strings.EqualFold(input, "U") || strings.EqualFold(input, "UNDO") || input == "<" {
 				s.Undo()
@@ -396,6 +385,17 @@ func (s *ManualGameService) playRound() {
 				s.Redo()
 				shouldRestartTurn = true
 				break
+			}
+
+			// Check for SAVE command
+			if strings.EqualFold(input, "SAVE") {
+				code, err := s.SaveState()
+				if err == nil {
+					fmt.Printf("\n[Save Code]: %s\n", code)
+				} else {
+					fmt.Printf("\nFailed to generate save code: %v\n", err)
+				}
+				continue
 			}
 
 			if strings.EqualFold(input, "S") {


### PR DESCRIPTION
This pull request updates the manual game service to change how the save code is displayed to the user. Instead of automatically showing the save code after each turn, it now hides the save code by default and introduces a new `SAVE` command that users can enter to view it on demand. The input prompt and command handling logic have been updated accordingly.

**User experience improvements:**

* The save code is no longer shown automatically after each turn; instead, users are informed that they can use the `SAVE` command to view it when needed.
* The input prompt has been updated to include `SAVE` as an available command, making it clear to users how to access the save code.

**Command handling enhancements:**

* Added logic to detect the `SAVE` command during input, generate the save code, and display it or an error message if generation fails.